### PR TITLE
Add quiet option to PythonTextGetter %cpaste cmd

### DIFF
--- a/sendtext+.py
+++ b/sendtext+.py
@@ -379,7 +379,7 @@ class PythonTextGetter(TextGetter):
         cmd = super(PythonTextGetter, self).get_text()
         cmd = cmd.rstrip("\n")
         if len(re.findall("\n", cmd)) > 0:
-            cmd = "%cpaste\n" + cmd + "\n--"
+            cmd = "%cpaste -q\n" + cmd + "\n--"
         return cmd
 
 


### PR DESCRIPTION
Silences the "`<Pasting code; enter '--' alone on the line to stop or use Ctrl-D.>`" message when sending a python block. Also removes the ":"s down the LHS of the block:

```python
In [18]: %cpaste
Pasting code; enter '--' alone on the line to stop or use Ctrl-D.
:def _cells(nb):
:    """Yield all cells in an nbformat-insensitive manner"""
:    if nb.nbformat < 4:
:        for ws in nb.worksheets:
:            for cell in ws.cells:
:                yield cell
:    else:
:        for cell in nb.cells:
:            yield cell
:--

In [19]: %cpaste -q 
def _cells(nb):
    """Yield all cells in an nbformat-insensitive manner"""
    if nb.nbformat < 4:
        for ws in nb.worksheets:
            for cell in ws.cells:
                yield cell
    else:
        for cell in nb.cells:
            yield cell
--
```

Means that sending a block is consistent with sending a single line