### PR TITLE
ipython5 support

### DIFF
--- a/textsender.py
+++ b/textsender.py
@@ -28,8 +28,8 @@ class TextSender:
     def wrap_paste_magic_for_python(self, cmd):
         if self.is_python():
             cmd = cmd.rstrip("\n")
-            if len(re.findall("\n", cmd)) > 0:
-                cmd = "%cpaste -q\n" + cmd + "\n--"
+            # if len(re.findall("\n", cmd)) > 0:
+            #     cmd = "%cpaste -q\n" + cmd + "\n--\n"
         return cmd
 
     def send_text(self, cmd):
@@ -82,6 +82,7 @@ class TextSender:
                      'tell application "Terminal" to do script ' + cmd + ' in front window'])
         subprocess.check_call(args)
 
+
     @staticmethod
     def iterm_version():
         args = ['osascript', '-e', 'tell application "iTerm" to get version']
@@ -103,9 +104,25 @@ class TextSender:
                 'to tell current session to write text '
             ])
         elif self.iterm_version() >= (2, 9):
+            if len(re.findall("\n", cmd)) > 0:
+                chunk = "%cpaste -q\n"
+                subprocess.check_call([
+                    'osascript', '-e',
+                    'tell application "iTerm" to tell the current window ' +
+                    'to tell current session to write text "' +
+                    self.escape_dquote(chunk) + '" without newline'
+                ])
             n = 1000
             chunks = [cmd[i:i+n] for i in range(0, len(cmd), n)]
             for chunk in chunks:
+                subprocess.check_call([
+                    'osascript', '-e',
+                    'tell application "iTerm" to tell the current window ' +
+                    'to tell current session to write text "' +
+                    self.escape_dquote(chunk) + '" without newline'
+                ])
+            if len(re.findall("\n", cmd)) > 0:
+                chunk = "\n--"
                 subprocess.check_call([
                     'osascript', '-e',
                     'tell application "iTerm" to tell the current window ' +
@@ -117,6 +134,7 @@ class TextSender:
                 'tell application "iTerm" to tell the current window ' +
                 'to tell current session to write text ""'
             ])
+
         else:
             subprocess.check_call([
                 'osascript', '-e',

--- a/textsender.py
+++ b/textsender.py
@@ -104,7 +104,7 @@ class TextSender:
                 'to tell current session to write text '
             ])
         elif self.iterm_version() >= (2, 9):
-            if len(re.findall("\n", cmd)) > 0:
+            if self.is_python() and len(re.findall("\n", cmd)) > 0:
                 chunk = "%cpaste -q\n"
                 subprocess.check_call([
                     'osascript', '-e',
@@ -121,7 +121,7 @@ class TextSender:
                     'to tell current session to write text "' +
                     self.escape_dquote(chunk) + '" without newline'
                 ])
-            if len(re.findall("\n", cmd)) > 0:
+            if self.is_python() and len(re.findall("\n", cmd)) > 0:
                 chunk = "\n--"
                 subprocess.check_call([
                     'osascript', '-e',


### PR DESCRIPTION
Addresses https://github.com/randy3k/SendTextPlus/issues/38 - tried sending text from st3 to ipython 5.0 in iterm2, though "%cpaste\n " was not sending a new line.  This PR breaks up the cpaste cmd into 3 cmds: the cpaste, then the chunked text, then the end of the cpaste cmd.  I didn't add any support for terminal.
